### PR TITLE
Add operational dashboard, trading-costs & order builder; enhance backtest and reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,20 @@ python scripts\merge_eod.py --datalake ..\etf-datalake --output data\eod.csv --r
 python examples\run_backtest.py --config ..\etf-trading-config\model.yaml --data data\eod.csv
 ```
 
+## Dashboard operativo
+
+La dashboard riunisce segnali, posizioni, KPI, confronto con benchmark e buy-and-hold
+e genera un piano operativo dimensionato per il rischio. Commissioni Fineco, spread e
+aliquota fiscale sono modificabili perché dipendono dal profilo e dalla posizione del cliente.
+
+```bash
+cd etf-trading-engine
+streamlit run dashboard.py
+```
+
+La dashboard legge gli artefatti dalla cartella `outputs/` (modificabile nella barra
+laterale): `signals/entries_today.csv`, `positions.csv`, `kpis.json` ed
+`equity_curve.csv`. Quest'ultimo può contenere le colonne `Date`, `Strategy`,
+`Benchmark` e `BuyHold`.
+
 > Nota: se il datalake GitHub è **privato**, il workflow richiederà PAT/token. Se è pubblico, parte subito.

--- a/etf-trading-config/model.yaml
+++ b/etf-trading-config/model.yaml
@@ -6,6 +6,9 @@ params:
   vol_z_min: -3.0
   vol_z_max: 3.0
 
+# Proxy configurabile mostrato accanto alla strategia e al buy-and-hold equiponderato.
+benchmark_ticker: "SWDA.MI"
+
 general:
   data:
     source: "web_yahoo"

--- a/etf-trading-config/operational.yaml
+++ b/etf-trading-config/operational.yaml
@@ -5,6 +5,7 @@ trading:
   sl_pct: 7
   tp_pct: 14
   p_win: 0.45
+  risk_per_trade_pct: 1.5
   horizon: "20–60 gg"
   prefer_signals: true
   tickers_override: []

--- a/etf-trading-engine/dashboard.py
+++ b/etf-trading-engine/dashboard.py
@@ -1,0 +1,67 @@
+"""Simple Streamlit control panel for daily ETF decisions."""
+
+from pathlib import Path
+import json
+import sys
+
+import pandas as pd
+import streamlit as st
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+from src.engine.operations import build_orders
+from src.engine.trading_costs import FinecoCosts
+
+
+st.set_page_config(page_title="ETF Trading Suite", page_icon="📈", layout="wide")
+st.title("📈 ETF Trading Suite")
+st.caption("Segnali, portafoglio e risultati in un unico pannello operativo")
+
+with st.sidebar:
+    st.header("Parametri")
+    output_dir = Path(st.text_input("Cartella risultati", "outputs"))
+    capital = st.number_input("Capitale (€)", min_value=0.0, value=10_000.0, step=1_000.0)
+    commission = st.number_input("Commissione Fineco per ordine (€)", 0.0, value=19.0)
+    spread = st.number_input("Spread (basis point)", 0.0, value=10.0)
+    tax = st.number_input("Fiscalità plusvalenze (%)", 0.0, 100.0, 26.0)
+    risk = st.number_input("Rischio per operazione (%)", 0.1, 100.0, 1.5)
+    st.info("Costi e fiscalità sono simulazioni configurabili: verificare il proprio profilo Fineco e la situazione fiscale.")
+
+
+def read_csv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path) if path.exists() else pd.DataFrame()
+
+
+signals = read_csv(output_dir / "signals" / "entries_today.csv")
+positions = read_csv(output_dir / "positions.csv")
+curve = read_csv(output_dir / "equity_curve.csv")
+kpis_path = output_dir / "kpis.json"
+kpis = json.loads(kpis_path.read_text()) if kpis_path.exists() else {}
+
+tab_signal, tab_positions, tab_performance, tab_report = st.tabs(
+    ["Segnali", "Posizioni", "Performance", "Report operativo"]
+)
+with tab_signal:
+    st.subheader("Segnali odierni")
+    st.dataframe(signals, use_container_width=True, hide_index=True) if not signals.empty else st.info("Nessun segnale disponibile.")
+with tab_positions:
+    st.subheader("Posizioni aperte")
+    st.dataframe(positions, use_container_width=True, hide_index=True) if not positions.empty else st.info("Nessuna posizione registrata in outputs/positions.csv.")
+with tab_performance:
+    cols = st.columns(4)
+    for col, (name, value) in zip(cols, kpis.items()):
+        col.metric(name, f"{value:.2%}" if name in {"MaxDD", "CAGR_sim"} else f"{value:.2f}")
+    if not curve.empty:
+        chart_cols = [c for c in ["Strategy", "Benchmark", "BuyHold"] if c in curve]
+        date_col = "Date" if "Date" in curve else None
+        st.line_chart(curve.set_index(date_col)[chart_cols] if date_col else curve[chart_cols])
+        if chart_cols:
+            st.dataframe(pd.DataFrame({"Rendimento totale": curve[chart_cols].iloc[-1] / curve[chart_cols].iloc[0] - 1}).style.format("{:.2%}"))
+    else:
+        st.info("Eseguire il backtest per confrontare strategia, benchmark e buy-and-hold.")
+with tab_report:
+    costs = FinecoCosts(commission, spread, tax / 100)
+    orders = build_orders(signals, capital, risk_pct=risk, costs=costs)
+    st.subheader("Piano per la prossima seduta")
+    st.dataframe(orders, use_container_width=True, hide_index=True)
+    st.download_button("Scarica report CSV", orders.to_csv(index=False).encode(), "report_operativo.csv", "text/csv")

--- a/etf-trading-engine/requirements.txt
+++ b/etf-trading-engine/requirements.txt
@@ -5,3 +5,4 @@ statsmodels>=0.14.2
 pyyaml>=6.0.1
 requests>=2.32.0
 yfinance>=0.2.40
+streamlit>=1.36.0

--- a/etf-trading-engine/scripts/operational_report.py
+++ b/etf-trading-engine/scripts/operational_report.py
@@ -8,6 +8,11 @@ import argparse, pandas as pd, numpy as np, json, sys, os
 from pathlib import Path
 from datetime import datetime, timezone
 
+ENGINE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ENGINE_ROOT))
+from src.engine.operations import build_orders
+from src.engine.trading_costs import FinecoCosts
+
 def safe_read_csv(path, **kwargs):
     p = Path(path)
     if not p.exists():
@@ -104,6 +109,9 @@ def main():
     ap.add_argument("--data", required=True, help="CSV EOD (Date,Ticker,Open,High,Low,Close,Volume...)")
     ap.add_argument("--config", required=False, help="operational.yaml (opzionale)")
     ap.add_argument("--outdir", required=True)
+    ap.add_argument("--commission", type=float, default=19.0, help="Commissione per eseguito in EUR")
+    ap.add_argument("--spread-bps", type=float, default=10.0, help="Spread denaro-lettera in basis point")
+    ap.add_argument("--tax-rate", type=float, default=26.0, help="Aliquota sulle plusvalenze in percentuale")
     args = ap.parse_args()
 
     outdir = Path(args.outdir); outdir.mkdir(parents=True, exist_ok=True)
@@ -118,6 +126,21 @@ def main():
 
     # segnali
     entries = load_signals(Path(outdir))
+
+    # Defaults compatible with operational.yaml; missing configuration stays safe.
+    trading = {}
+    if args.config and Path(args.config).exists():
+        try:
+            import yaml
+            trading = (yaml.safe_load(Path(args.config).read_text(encoding="utf-8")) or {}).get("trading", {})
+        except Exception as e:
+            print(f"[WARN] config non parsabile: {e}", file=sys.stderr)
+    capital = float(trading.get("capital_eur", 10_000))
+    risk_pct = float(trading.get("risk_per_trade_pct", 1.5))
+    costs = FinecoCosts(args.commission, args.spread_bps, args.tax_rate / 100)
+    orders = build_orders(entries, capital, risk_pct, float(trading.get("sl_pct", 7)),
+                          float(trading.get("tp_pct", 14)), costs,
+                          int(trading.get("lines", 3)))
 
     # drawdown medio (fallback)
     dd_avg = simple_drawdown(eod)
@@ -151,6 +174,9 @@ def main():
     md.append("")
     if expected_cycle is not None:
         md.append(f"**Payoff medio atteso (TP1/Stop) sulle proposte di oggi:** ~{expected_cycle:.2f}x\n")
+    md.append("## Piano operativo\n")
+    md.append(md_table(orders, max_rows=20))
+    md.append(f"\n_Costi simulati: €{args.commission:.2f} per ordine, spread {args.spread_bps:.1f} bps, fiscalità {args.tax_rate:.1f}%. Verificare le condizioni personali._\n")
     md_text = "\n".join(md).strip() + "\n"
 
     # Write outputs
@@ -166,6 +192,7 @@ def main():
         "payoff_mean_estimate": expected_cycle
     }
     (outdir / "operational_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    orders.to_csv(outdir / "operational_orders.csv", index=False)
     print("[OK] operational_report.md scritto")
 
 if __name__ == "__main__":

--- a/etf-trading-engine/scripts/run_ci_backtest.py
+++ b/etf-trading-engine/scripts/run_ci_backtest.py
@@ -19,7 +19,7 @@ def main():
 
     outdir = Path(args.outdir); outdir.mkdir(parents=True, exist_ok=True)
     (outdir / 'kpis.json').write_text(json.dumps(kpis, indent=2), encoding='utf-8')
-    pd.DataFrame({'Equity': res['equity_curve']}).to_csv(outdir / 'equity_curve.csv', index=False)
+    res['curves'].to_csv(outdir / 'equity_curve.csv', index=False)
 
     with open(outdir / 'summary.txt', 'w', encoding='utf-8') as f:
         f.write("KPIs (CI Backtest)\n")

--- a/etf-trading-engine/scripts/signals.py
+++ b/etf-trading-engine/scripts/signals.py
@@ -146,6 +146,8 @@ def main():
     # Liquidity
     base['ADV20']  = _last_by_ticker(_adv(eod, 20))
     base['Volume'] = _last_by_ticker(eod['Volume']) if 'Volume' in eod.columns else 0.0
+    # An actionable report needs a reference entry level, not only a rank.
+    base['Entry'] = _last_by_ticker(eod['Close'])
 
     # Merge with external features if provided (left join)
     if not feat_last.empty:

--- a/etf-trading-engine/src/engine/backtest.py
+++ b/etf-trading-engine/src/engine/backtest.py
@@ -6,7 +6,8 @@ from .metrics import sharpe, max_drawdown, calmar, profit_factor
 def run_backtest(prices: pd.DataFrame, config: dict) -> dict:
     tickers = prices['Ticker'].unique().tolist()
     equity = 10000.0
-    daily_returns = []
+    strategy_returns = []
+    buy_hold_returns = []
 
     for t in tickers:
         df = prices[prices['Ticker']==t].sort_values('Date').reset_index(drop=True)
@@ -16,11 +17,24 @@ def run_backtest(prices: pd.DataFrame, config: dict) -> dict:
                               vol_z_min=config['params']['vol_z_min'])
         df = df.merge(sig, on=['Date','Close'], how='left')
         df['Position'] = (df['Entry'].notna()).astype(int).shift(1).fillna(0)
-        ret = df['Close'].pct_change().fillna(0) * df['Position']
-        daily_returns.append(ret)
+        raw_ret = df.set_index('Date')['Close'].pct_change().fillna(0)
+        position = pd.Series(df['Position'].to_numpy(), index=df['Date'])
+        strategy_returns.append(raw_ret.mul(position).rename(t))
+        buy_hold_returns.append(raw_ret.rename(t))
 
-    returns = sum(daily_returns) / max(1,len(daily_returns)) if daily_returns else pd.Series([0.0])
+    strategy_frame = pd.concat(strategy_returns, axis=1) if strategy_returns else pd.DataFrame()
+    hold_frame = pd.concat(buy_hold_returns, axis=1) if buy_hold_returns else pd.DataFrame()
+    returns = strategy_frame.mean(axis=1, skipna=True).fillna(0) if not strategy_frame.empty else pd.Series([0.0])
+    hold_returns = hold_frame.mean(axis=1, skipna=True).fillna(0) if not hold_frame.empty else returns
+    benchmark_ticker = config.get('benchmark_ticker', 'SWDA.MI')
+    if not hold_frame.empty:
+        benchmark_returns = hold_frame[benchmark_ticker] if benchmark_ticker in hold_frame else hold_frame.iloc[:, 0]
+        benchmark_returns = benchmark_returns.reindex(returns.index).fillna(0)
+    else:
+        benchmark_returns = returns
     equity_curve = (1+returns).cumprod()*equity
+    buy_hold_curve = (1+hold_returns.reindex(returns.index).fillna(0)).cumprod()*equity
+    benchmark_curve = (1+benchmark_returns).cumprod()*equity
 
     kpis = {
         'Sharpe': sharpe(returns),
@@ -29,4 +43,11 @@ def run_backtest(prices: pd.DataFrame, config: dict) -> dict:
         'ProfitFactor': profit_factor(returns),
         'CAGR_sim': (equity_curve.iloc[-1]/equity_curve.iloc[0])**(252/len(equity_curve)) - 1.0
     }
-    return {'equity_curve': equity_curve.tolist(), 'kpis': kpis}
+    curves = pd.DataFrame({
+        'Date': returns.index,
+        'Strategy': equity_curve.to_numpy(),
+        'Benchmark': benchmark_curve.to_numpy(),
+        'BuyHold': buy_hold_curve.to_numpy(),
+    })
+    return {'equity_curve': equity_curve.tolist(), 'curves': curves, 'kpis': kpis,
+            'benchmark_ticker': benchmark_ticker}

--- a/etf-trading-engine/src/engine/operations.py
+++ b/etf-trading-engine/src/engine/operations.py
@@ -1,0 +1,34 @@
+"""Generate executable, auditable trading proposals from ranked signals."""
+
+import pandas as pd
+
+from .trading_costs import FinecoCosts, position_size
+
+
+def build_orders(signals: pd.DataFrame, capital: float, risk_pct: float = 1.5,
+                 stop_pct: float = 7.0, take_profit_pct: float = 14.0,
+                 costs: FinecoCosts | None = None, max_positions: int = 3) -> pd.DataFrame:
+    costs = costs or FinecoCosts()
+    columns = ["Ticker", "Action", "Entry", "Exit", "Stop", "Target", "Quantity",
+               "PositionValue", "RiskEUR", "CommissionRT", "TaxRate", "Reason"]
+    if signals.empty or "Ticker" not in signals:
+        return pd.DataFrame(columns=columns)
+    price_col = next((c for c in ("Entry", "Close", "Price") if c in signals), None)
+    if not price_col:
+        return pd.DataFrame(columns=columns)
+    rows = []
+    allocation_pct = 100 / max(1, max_positions)
+    for _, signal in signals.head(max_positions).iterrows():
+        entry = float(signal[price_col])
+        stop = float(signal.get("Stop", entry * (1 - stop_pct / 100)))
+        target = float(signal.get("TP1", signal.get("Target", entry * (1 + take_profit_pct / 100))))
+        qty = position_size(capital, risk_pct, entry, stop, costs, allocation_pct)
+        rows.append({
+            "Ticker": signal["Ticker"], "Action": "BUY", "Entry": entry,
+            "Exit": f"Target {target:.2f} o stop {stop:.2f}", "Stop": stop,
+            "Target": target, "Quantity": qty, "PositionValue": qty * entry,
+            "RiskEUR": qty * (entry - stop) + 2 * costs.commission_eur,
+            "CommissionRT": 2 * costs.commission_eur, "TaxRate": costs.tax_rate,
+            "Reason": signal.get("Reason", "Segnale quantitativo"),
+        })
+    return pd.DataFrame(rows, columns=columns)

--- a/etf-trading-engine/src/engine/trading_costs.py
+++ b/etf-trading-engine/src/engine/trading_costs.py
@@ -1,0 +1,51 @@
+"""Italian retail trading costs and position sizing utilities."""
+
+from dataclasses import dataclass
+import math
+
+
+@dataclass(frozen=True)
+class FinecoCosts:
+    """Configurable approximation of a Fineco execution profile.
+
+    Fees vary by customer profile and market, therefore every value is exposed
+    in the UI/configuration rather than presented as an authoritative tariff.
+    """
+
+    commission_eur: float = 19.0
+    spread_bps: float = 10.0
+    tax_rate: float = 0.26
+
+    def execution_price(self, mid_price: float, side: str) -> float:
+        half_spread = self.spread_bps / 20_000
+        return mid_price * (1 + half_spread if side.upper() == "BUY" else 1 - half_spread)
+
+    def round_trip_cost(self, quantity: int, entry: float, exit_price: float) -> dict:
+        buy = self.execution_price(entry, "BUY")
+        sell = self.execution_price(exit_price, "SELL")
+        gross = quantity * (sell - buy)
+        commissions = 2 * self.commission_eur
+        taxable_profit = max(0.0, gross - commissions)
+        tax = taxable_profit * self.tax_rate
+        return {
+            "gross_pnl": gross,
+            "commissions": commissions,
+            "tax": tax,
+            "net_pnl": gross - commissions - tax,
+            "buy_price": buy,
+            "sell_price": sell,
+        }
+
+
+def position_size(capital: float, risk_pct: float, entry: float, stop: float,
+                  costs: FinecoCosts, max_allocation_pct: float = 100.0) -> int:
+    """Return whole units bounded by risk budget and available allocation."""
+    if capital <= 0 or entry <= 0 or stop >= entry or risk_pct <= 0:
+        return 0
+    buy = costs.execution_price(entry, "BUY")
+    risk_per_unit = buy - costs.execution_price(stop, "SELL")
+    risk_budget = capital * risk_pct / 100 - 2 * costs.commission_eur
+    allocation = capital * max_allocation_pct / 100
+    by_risk = math.floor(max(0.0, risk_budget) / risk_per_unit)
+    by_cash = math.floor(max(0.0, allocation - costs.commission_eur) / buy)
+    return max(0, min(by_risk, by_cash))

--- a/etf-trading-engine/tests/test_backtest_comparison.py
+++ b/etf-trading-engine/tests/test_backtest_comparison.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from src.engine.backtest import run_backtest
+
+
+def test_backtest_returns_aligned_comparison_curves():
+    dates = pd.date_range("2025-01-01", periods=30)
+    rows = []
+    for ticker, offset in (("AAA", 0), ("BBB", 10)):
+        for i, date in enumerate(dates):
+            close = 100 + offset + i
+            rows.append({"Date": date, "Ticker": ticker, "Open": close,
+                         "High": close + 1, "Low": close - 1, "Close": close,
+                         "Volume": 1000 + i})
+    config = {"params": {"atr_pct": 1, "buffer_mult": 1, "vol_z_min": -3},
+              "benchmark_ticker": "BBB"}
+    result = run_backtest(pd.DataFrame(rows), config)
+    assert list(result["curves"].columns) == ["Date", "Strategy", "Benchmark", "BuyHold"]
+    assert len(result["curves"]) == len(dates)
+    assert result["benchmark_ticker"] == "BBB"

--- a/etf-trading-engine/tests/test_trading_costs.py
+++ b/etf-trading-engine/tests/test_trading_costs.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from src.engine.operations import build_orders
+from src.engine.trading_costs import FinecoCosts, position_size
+
+
+def test_costs_include_spread_commission_and_tax():
+    costs = FinecoCosts(commission_eur=10, spread_bps=20, tax_rate=.26)
+    result = costs.round_trip_cost(10, 100, 110)
+    assert result["buy_price"] == 100.1
+    assert result["sell_price"] == 109.89
+    assert result["tax"] > 0
+    assert result["net_pnl"] < result["gross_pnl"]
+
+
+def test_position_size_respects_cash_and_risk():
+    costs = FinecoCosts(commission_eur=0, spread_bps=0)
+    assert position_size(10_000, 1, 100, 95, costs) == 20
+    assert position_size(10_000, 1, 100, 100, costs) == 0
+
+
+def test_operational_orders_have_required_levels():
+    signals = pd.DataFrame([{"Ticker": "ETF.MI", "Entry": 100, "Reason": "breakout"}])
+    orders = build_orders(signals, 10_000, costs=FinecoCosts(0, 0))
+    assert orders.loc[0, "Stop"] == 93
+    assert round(orders.loc[0, "Target"], 8) == 114
+    assert orders.loc[0, "Quantity"] > 0
+    assert "stop" in orders.loc[0, "Exit"]


### PR DESCRIPTION
### Motivation
- Provide an operational control panel and executable order proposals to bridge backtest artifacts and live decision-making. 
- Model realistic Italian retail trading costs and position sizing to produce auditable orders and P&L estimates. 
- Improve backtest output to include aligned comparison curves (strategy, benchmark, buy-and-hold) for richer reporting. 

### Description
- Added a Streamlit dashboard at `etf-trading-engine/dashboard.py` that reads `outputs/` artifacts and builds a downloadable operational orders report using `build_orders`. 
- Introduced trading cost and sizing utilities in `src/engine/trading_costs.py` (`FinecoCosts`, `position_size`) and an order builder in `src/engine/operations.py` (`build_orders`). 
- Enhanced the backtest to compute per-ticker strategy and buy-and-hold returns and return unified comparison `curves` (DataFrame with `Date`, `Strategy`, `Benchmark`, `BuyHold`) and `benchmark_ticker` in `src/engine/backtest.py`. 
- Updated scripts and configuration: added dashboard instructions to `README.md`, added `benchmark_ticker` to `model.yaml`, added `risk_per_trade_pct` to `operational.yaml`, updated `requirements.txt` to include `streamlit`, changed CI backtest output to write `curves` to `equity_curve.csv`, and extended `scripts/operational_report.py` to generate operational orders and include costs in the markdown. 

### Testing
- Added unit tests `tests/test_backtest_comparison.py`, `tests/test_trading_costs.py` that assert presence and alignment of comparison curves, correctness of cost calculations, sizing limits, and order fields. 
- Ran the test suite with `pytest -q` and the new tests completed successfully. 
- Verified the CI backtest script writes the new `equity_curve.csv` format and the operational report script writes `operational_orders.csv` when orders are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67ae89ffbc832b903c71f58c60a284)