### PR TITLE
Add false-breakdown reclaim strategy

### DIFF
--- a/etf-trading-config/model.yaml
+++ b/etf-trading-config/model.yaml
@@ -122,3 +122,17 @@ runs:
     take_profit: {mode: "moving_average", field: "EMA20", fallback_atr_multiple: 1.5, tp2_atr_multiple: 3.0}
     risk: {risk_per_trade_pct: 0.50}
     guardrails: {sharpe_min: 0.20, profit_factor_min: 1.05, maxdd_abs_max_pct: 20.0, wf_calmar_cov_max_pct: 35.0}
+
+  S8_false_breakdown_reclaim:
+    description: "Recupero rapido di un supporto storico dopo una falsa rottura ribassista"
+    universe: "etf-trading-config/universe.csv"
+    entry:
+      {mode: "false_breakdown_reclaim", support_lookback_days: 63,
+       support_min_periods: 40, support_quantile: 0.10, min_support_touches: 2,
+       touch_tolerance_atr: 0.50, break_buffer_atr: 0.10,
+       reclaim_buffer_atr: 0.0, max_reclaim_days: 3,
+       min_close_location: 0.60, require_bullish_close: false}
+    stop_loss: {mode: "breakdown_low_atr", atr_multiplier: 0.25}
+    take_profit: {mode: "moving_average", field: "EMA20", fallback_atr_multiple: 2.0, tp2_atr_multiple: 3.0}
+    risk: {risk_per_trade_pct: 0.50}
+    guardrails: {sharpe_min: 0.20, profit_factor_min: 1.05, maxdd_abs_max_pct: 20.0, wf_calmar_cov_max_pct: 35.0}

--- a/etf-trading-engine/src/engine/backtest.py
+++ b/etf-trading-engine/src/engine/backtest.py
@@ -11,7 +11,7 @@ from .metrics import sharpe, max_drawdown, calmar, profit_factor
 from .strategy import (
     enrich, breakout_entries, channel_rebound_entries,
     multi_horizon_breakout_entries, trend_pullback_entries,
-    shock_reversion_entries,
+    shock_reversion_entries, false_breakdown_reclaim_entries,
 )
 
 
@@ -106,6 +106,8 @@ def _strategy_signals(df: pd.DataFrame, name: str, cfg: dict) -> pd.Series:
         return multi_horizon_breakout_entries(df, cfg.get("entry", {}))
     if name == "S7_shock_reversion":
         return shock_reversion_entries(df, cfg.get("entry", {}))
+    if name == "S8_false_breakdown_reclaim":
+        return false_breakdown_reclaim_entries(df, cfg.get("entry", {}))
     raise ValueError(f"Unsupported run: {name}")
 
 
@@ -147,6 +149,9 @@ def _simulate_ticker(df: pd.DataFrame, ticker: str, name: str, cfg: dict,
             elif stop_cfg and stop_cfg.get("mode") == "signal_low_atr":
                 stop = float(df.loc[i - 1, "Low"]) - \
                     float(stop_cfg.get("atr_multiplier", 0.5)) * float(df.loc[i - 1, "ATR14"])
+            elif stop_cfg and stop_cfg.get("mode") == "breakdown_low_atr":
+                stop = float(df.loc[i - 1, "FalseBreakdownLow"]) - \
+                    float(stop_cfg.get("atr_multiplier", 0.25)) * float(df.loc[i - 1, "ATR14"])
             else:
                 stop = math.nan
             if tp_cfg and tp_cfg.get("mode") == "percent":
@@ -311,6 +316,18 @@ def latest_orders(prices: pd.DataFrame, name: str, cfg: dict, general: dict) -> 
                 tp1 = entry * (1 + float(tp_cfg.get("value_pct", 10.0)) / 100)
             tp2 = entry + float(tp_cfg.get("tp2_atr_multiple", 3.0)) * float(row.ATR14)
             reason = str(cfg.get("entry", {}).get("mode", name))
+        elif cfg.get("stop_loss", {}).get("mode") == "breakdown_low_atr":
+            stop = float(row.FalseBreakdownLow) - float(
+                cfg["stop_loss"].get("atr_multiplier", 0.25)
+            ) * float(row.ATR14)
+            tp_cfg = cfg.get("take_profit", {})
+            tp1 = float(row[str(tp_cfg.get("field", "EMA20"))])
+            if tp1 <= entry:
+                tp1 = entry + float(
+                    tp_cfg.get("fallback_atr_multiple", 2.0)
+                ) * float(row.ATR14)
+            tp2 = entry + float(tp_cfg.get("tp2_atr_multiple", 3.0)) * float(row.ATR14)
+            reason = "confirmed_false_breakdown_reclaim"
         else:
             stop = entry * (1 - float(cfg["stop_loss"]["value_pct"]) / 100)
             tp1 = entry * (1 + float(cfg["take_profit"]["value_pct"]) / 100)

--- a/etf-trading-engine/src/engine/strategy.py
+++ b/etf-trading-engine/src/engine/strategy.py
@@ -107,6 +107,82 @@ def shock_reversion_entries(df: pd.DataFrame, cfg: dict) -> pd.Series:
     return confirmation.fillna(False)
 
 
+def false_breakdown_reclaim_entries(df: pd.DataFrame, cfg: dict) -> pd.Series:
+    """Reclaim of a previously established support after a downside break.
+
+    Support and touch counts are shifted by one bar, so the level being tested
+    never uses the breakdown or confirmation bar. A reclaim may happen on the
+    breakdown bar itself or within ``max_reclaim_days`` subsequent bars.
+    Diagnostic columns are attached to ``df`` for stop/target generation.
+    """
+    lookback = int(cfg.get("support_lookback_days", 63))
+    min_periods = int(cfg.get("support_min_periods", max(20, lookback // 2)))
+    quantile = float(cfg.get("support_quantile", 0.10))
+    min_touches = int(cfg.get("min_support_touches", 2))
+    touch_tolerance = float(cfg.get("touch_tolerance_atr", 0.50))
+    break_buffer = float(cfg.get("break_buffer_atr", 0.10))
+    reclaim_buffer = float(cfg.get("reclaim_buffer_atr", 0.0))
+    max_reclaim_days = int(cfg.get("max_reclaim_days", 3))
+    min_close_location = float(cfg.get("min_close_location", 0.60))
+    if not (2 <= lookback and 1 <= min_periods <= lookback):
+        raise ValueError("Invalid false-breakdown support window")
+    if not (0.0 <= quantile <= 0.5) or min_touches < 1 or max_reclaim_days < 0:
+        raise ValueError("Invalid false-breakdown configuration")
+
+    prior_low = df["Low"].shift(1)
+    support = prior_low.rolling(lookback, min_periods=min_periods).quantile(quantile)
+    # Count only contacts known before the current bar.
+    distance = (prior_low - support).abs()
+    touches = distance.le(touch_tolerance * df["ATR14"].shift(1)).rolling(
+        lookback, min_periods=min_periods
+    ).sum()
+    bar_range = (df["High"] - df["Low"]).replace(0, np.nan)
+    close_location = (df["Close"] - df["Low"]) / bar_range
+
+    signals = pd.Series(False, index=df.index)
+    frozen_support = pd.Series(np.nan, index=df.index, dtype=float)
+    breakdown_low = pd.Series(np.nan, index=df.index, dtype=float)
+    active_support = np.nan
+    active_low = np.nan
+    age = -1
+
+    for i in range(len(df)):
+        atr_i = float(df["ATR14"].iloc[i]) if pd.notna(df["ATR14"].iloc[i]) else np.nan
+        support_i = float(support.iloc[i]) if pd.notna(support.iloc[i]) else np.nan
+        qualified = (
+            np.isfinite(atr_i) and np.isfinite(support_i) and
+            touches.iloc[i] >= min_touches
+        )
+        broke = qualified and float(df["Low"].iloc[i]) <= support_i - break_buffer * atr_i
+        if broke and age < 0:
+            active_support = support_i
+            active_low = float(df["Low"].iloc[i])
+            age = 0
+        elif age >= 0:
+            age += 1
+            active_low = min(active_low, float(df["Low"].iloc[i]))
+
+        if age >= 0:
+            reclaimed = (
+                age <= max_reclaim_days and
+                float(df["Close"].iloc[i]) >= active_support + reclaim_buffer * atr_i and
+                close_location.iloc[i] >= min_close_location
+            )
+            if bool(cfg.get("require_bullish_close", False)):
+                reclaimed = reclaimed and float(df["Close"].iloc[i]) > float(df["Open"].iloc[i])
+            if reclaimed:
+                signals.iloc[i] = True
+                frozen_support.iloc[i] = active_support
+                breakdown_low.iloc[i] = active_low
+                age = -1
+            elif age > max_reclaim_days:
+                age = -1
+
+    df["FalseBreakdownSupport"] = frozen_support
+    df["FalseBreakdownLow"] = breakdown_low
+    return signals.fillna(False)
+
+
 def descending_channel(df: pd.DataFrame, lookback: int = 45) -> pd.DataFrame:
     """Rolling robust-ish channel based on OLS residual quantiles.
 

--- a/etf-trading-engine/tests/test_smoke.py
+++ b/etf-trading-engine/tests/test_smoke.py
@@ -3,7 +3,7 @@ from src.engine.metrics import sharpe, max_drawdown, calmar, profit_factor
 from src.engine.strategy import (
     breakout_entries, channel_rebound_entries, enrich,
     multi_horizon_breakout_entries, trend_pullback_entries,
-    shock_reversion_entries,
+    shock_reversion_entries, false_breakdown_reclaim_entries,
 )
 import pandas as pd
 import numpy as np
@@ -90,6 +90,21 @@ def config(active="S1_breakout"):
                 "take_profit": {"mode": "moving_average", "field": "EMA20",
                                 "fallback_atr_multiple": 1.5},
             },
+            "S8_false_breakdown_reclaim": {
+                "entry": {"mode": "false_breakdown_reclaim",
+                          "support_lookback_days": 20,
+                          "support_min_periods": 10,
+                          "support_quantile": 0.10,
+                          "min_support_touches": 1,
+                          "touch_tolerance_atr": 1.0,
+                          "break_buffer_atr": 0.05,
+                          "reclaim_buffer_atr": 0.0,
+                          "max_reclaim_days": 2,
+                          "min_close_location": 0.55},
+                "stop_loss": {"mode": "breakdown_low_atr", "atr_multiplier": 0.25},
+                "take_profit": {"mode": "moving_average", "field": "EMA20",
+                                "fallback_atr_multiple": 2.0},
+            },
         },
     }
 
@@ -175,8 +190,46 @@ def test_shock_reversion_does_not_fire_on_shock_bar():
     assert signal.iloc[-1]
 
 
+def test_false_breakdown_uses_prior_support_and_requires_reclaim():
+    df = prices(50)
+    close = np.full(len(df), 100.0)
+    close[-2:] = [97.5, 100.2]
+    df["Close"] = close
+    df["Open"] = close
+    df["High"] = close + 0.5
+    df["Low"] = close - 0.5
+    df.loc[df.index[-2], ["Open", "High", "Low", "Close"]] = [100.0, 100.2, 96.5, 97.5]
+    # Reclaims the old frozen level but does not create a fresh breakdown.
+    df.loc[df.index[-1], ["Open", "High", "Low", "Close"]] = [99.7, 100.5, 99.6, 100.2]
+    out = enrich(df)
+    signal = false_breakdown_reclaim_entries(out, {
+        "support_lookback_days": 20, "support_min_periods": 10,
+        "support_quantile": 0.10, "min_support_touches": 1,
+        "touch_tolerance_atr": 1.0, "break_buffer_atr": 0.05,
+        "max_reclaim_days": 2, "min_close_location": 0.55,
+    })
+    assert not signal.iloc[-2]
+    assert signal.iloc[-1]
+    assert out["FalseBreakdownLow"].iloc[-1] == pytest.approx(96.5)
+
+
+def test_false_breakdown_does_not_reclaim_after_expiry():
+    df = prices(55)
+    df[["Open", "High", "Low", "Close"]] = [100.0, 100.5, 99.5, 100.0]
+    df.loc[df.index[-4], ["Open", "High", "Low", "Close"]] = [100.0, 100.2, 96.5, 97.0]
+    df.loc[df.index[-1], ["Open", "High", "Low", "Close"]] = [98.0, 100.5, 97.8, 100.2]
+    signal = false_breakdown_reclaim_entries(enrich(df), {
+        "support_lookback_days": 20, "support_min_periods": 10,
+        "support_quantile": 0.10, "min_support_touches": 1,
+        "touch_tolerance_atr": 1.0, "break_buffer_atr": 0.05,
+        "max_reclaim_days": 2, "min_close_location": 0.55,
+    })
+    assert not signal.iloc[-1]
+
+
 @pytest.mark.parametrize("active", [
-    "S5_trend_pullback", "S6_multi_horizon_breakout", "S7_shock_reversion"
+    "S5_trend_pullback", "S6_multi_horizon_breakout", "S7_shock_reversion",
+    "S8_false_breakdown_reclaim",
 ])
 def test_new_strategies_execute(active):
     out = run_backtest(prices(), config(active))


### PR DESCRIPTION
## Cosa cambia

- aggiunge S8 per riconoscere una falsa rottura ribassista e il rapido recupero di un supporto storico
- calcola il supporto esclusivamente con dati precedenti, evitando look-ahead
- usa il minimo effettivo del breakdown per lo stop
- genera ordini e livelli con le stesse regole del backtest
- include S8 nel confronto walk-forward senza renderla la strategia attiva predefinita

## Perché

La lettura discrezionale usata su SEME non era ancora rappresentata dal modello. La nuova strategia la rende misurabile e confrontabile con S7 senza codificare livelli specifici di SEME.

## Verifiche

- 20 test superati
- YAML valido
- controllo sintattico e `git diff --check` superati
- test storico preliminare non promuove S8: resta candidata da validare fuori campione