### PR TITLE
Add adaptive trade levels and false-breakdown strategy

### DIFF
--- a/etf-trading-config/model.yaml
+++ b/etf-trading-config/model.yaml
@@ -38,11 +38,11 @@ runs:
     guardrails: {sharpe_min: -999.0, profit_factor_min: 0.0, maxdd_abs_max_pct: 100.0, wf_calmar_cov_max_pct: 100.0}
 
   S1_breakout:
-    description: "Breakout 52w +0,3% con SL -7% e TP +14%"
+    description: "Breakout 52w +0,3% con livelli adattivi a volatilità e struttura"
     universe: "etf-trading-config/universe.csv"
     entry: {mode: "breakout_52w", lookback_days: 252, buffer_pct: 0.3}
-    stop_loss: {mode: "percent", value_pct: 7.0}
-    take_profit: {mode: "percent", value_pct: 14.0}
+    stop_loss: {mode: "adaptive_atr_structure", lookback_days: 20, atr_multiple: 2.5, structure_buffer_atr: 0.25}
+    take_profit: {mode: "adaptive_risk_atr", risk_multiple: 2.0, min_atr_multiple: 3.0}
     exit: {break_even_after_tp1: false}
     guardrails: {sharpe_min: 0.30, profit_factor_min: 1.10, maxdd_abs_max_pct: 35.0, wf_calmar_cov_max_pct: 30.0}
 
@@ -54,20 +54,20 @@ runs:
       scaling_tranches:
         - {mode: "market_now", weight_pct: 33.0}
         - {mode: "pullback_dma", dmas: [20, 50], weight_pct: 33.0, tolerance_atr: 0.35, rsi_min: 30, rsi_max: 55, stop_atr_multiplier: 0.60}
-        - {mode: "multi_horizon_breakout", lookback_days: [63, 126, 252], min_confirmations: 2, buffer_pct: 0.3, stop_pct: 10.0, weight_pct: 34.0}
+        - {mode: "multi_horizon_breakout", lookback_days: [63, 126, 252], min_confirmations: 2, buffer_pct: 0.3, stop_lookback_days: 20, stop_atr_multiple: 2.5, structure_buffer_atr: 0.25, weight_pct: 34.0}
       trailing_pct_by_ticker: {TNOW.MI: 12.0, XAIX.MI: 15.0, default: 12.0}
     tactical:
       entry: {mode: "breakout_52w", buffer_pct: 0.3}
-      stop_loss: {mode: "percent", value_pct: 7.0}
-      take_profit: {mode: "percent", value_pct: 14.0}
+      stop_loss: {mode: "adaptive_atr_structure", lookback_days: 20, atr_multiple: 2.5, structure_buffer_atr: 0.25}
+      take_profit: {mode: "adaptive_risk_atr", risk_multiple: 2.0, min_atr_multiple: 3.0}
     guardrails: {sharpe_min: 0.30, profit_factor_min: 1.10, maxdd_abs_max_pct: 35.0, wf_calmar_cov_max_pct: 30.0}
 
   S3_breakout_checklist:
     description: "Breakout 52w + filtri (NAV P/D, spread, stagionalità, regime, breadth)"
     universe: "etf-trading-config/universe.csv"
     entry: {mode: "breakout_52w", buffer_pct: 0.3}
-    stop_loss: {mode: "percent", value_pct: 7.0}
-    take_profit: {mode: "percent", value_pct: 14.0}
+    stop_loss: {mode: "adaptive_atr_structure", lookback_days: 20, atr_multiple: 2.5, structure_buffer_atr: 0.25}
+    take_profit: {mode: "adaptive_risk_atr", risk_multiple: 2.0, min_atr_multiple: 3.0}
     filters:
       nav_premium_abs_max_pct: 0.5
       spread_median_max_pct: 0.25
@@ -97,7 +97,7 @@ runs:
       {mode: "trend_pullback", tolerance_atr: 0.35, rsi_min: 30, rsi_max: 55,
        sma50_slope_min: 0.0}
     stop_loss: {mode: "signal_low_atr", atr_multiplier: 0.60}
-    take_profit: {mode: "percent", value_pct: 12.0, tp2_atr_multiple: 3.0}
+    take_profit: {mode: "moving_average", field: "SMA50", fallback_atr_multiple: 2.0, tp2_atr_multiple: 3.0}
     risk: {risk_per_trade_pct: 0.75}
     guardrails: {sharpe_min: 0.30, profit_factor_min: 1.10, maxdd_abs_max_pct: 25.0, wf_calmar_cov_max_pct: 30.0}
 
@@ -107,8 +107,8 @@ runs:
     entry:
       {mode: "multi_horizon_breakout", lookback_days: [20, 63, 126, 252],
        min_confirmations: 2, buffer_pct: 0.3, trend_filter: true}
-    stop_loss: {mode: "percent", value_pct: 7.0}
-    take_profit: {mode: "percent", value_pct: 14.0}
+    stop_loss: {mode: "adaptive_atr_structure", lookback_days: 20, atr_multiple: 2.5, structure_buffer_atr: 0.25}
+    take_profit: {mode: "adaptive_risk_atr", risk_multiple: 2.0, min_atr_multiple: 3.0}
     risk: {risk_per_trade_pct: 1.0}
     guardrails: {sharpe_min: 0.30, profit_factor_min: 1.10, maxdd_abs_max_pct: 30.0, wf_calmar_cov_max_pct: 30.0}
 

--- a/etf-trading-engine/src/engine/backtest.py
+++ b/etf-trading-engine/src/engine/backtest.py
@@ -87,6 +87,32 @@ def _commission(notional: float, costs: dict) -> float:
     return costs["commission_fixed"] + abs(notional) * costs["commission_pct"]
 
 
+def _adaptive_levels(df: pd.DataFrame, signal_index: int, entry: float,
+                     cfg: dict) -> tuple[float, float]:
+    """Calculate volatility- and structure-aware levels for one operation."""
+    stop_cfg = cfg.get("stop_loss", {})
+    tp_cfg = cfg.get("take_profit", {})
+    lookback = int(stop_cfg.get("lookback_days", 20))
+    atr_value = float(df.loc[signal_index, "ATR14"])
+    recent_low = float(
+        df.loc[max(0, signal_index - lookback + 1):signal_index, "Low"].min()
+    )
+    atr_stop = entry - float(stop_cfg.get("atr_multiple", 2.5)) * atr_value
+    structural_stop = recent_low - float(
+        stop_cfg.get("structure_buffer_atr", 0.25)
+    ) * atr_value
+    # Use the nearer valid protection while requiring room for normal volatility.
+    stop = max(atr_stop, structural_stop)
+    if not math.isfinite(stop) or stop >= entry:
+        stop = atr_stop
+    risk = entry - stop
+    target = entry + max(
+        float(tp_cfg.get("risk_multiple", 2.0)) * risk,
+        float(tp_cfg.get("min_atr_multiple", 3.0)) * atr_value,
+    )
+    return stop, target
+
+
 def _strategy_signals(df: pd.DataFrame, name: str, cfg: dict) -> pd.Series:
     if name == "S0_buyhold":
         signal = pd.Series(False, index=df.index)
@@ -142,6 +168,8 @@ def _simulate_ticker(df: pd.DataFrame, ticker: str, name: str, cfg: dict,
             entry = _fill(float(row.Open), "buy", costs)
             if stop_cfg and stop_cfg.get("mode") == "percent":
                 stop = entry * (1 - float(stop_cfg["value_pct"]) / 100)
+            elif stop_cfg and stop_cfg.get("mode") == "adaptive_atr_structure":
+                stop, _ = _adaptive_levels(df, i - 1, entry, cfg)
             elif name == "S4_channel_rebound":
                 mult = float(stop_cfg.get("atr_multiplier", 0.6))
                 stop = min(float(df.loc[i - 1, "Low"]),
@@ -156,6 +184,8 @@ def _simulate_ticker(df: pd.DataFrame, ticker: str, name: str, cfg: dict,
                 stop = math.nan
             if tp_cfg and tp_cfg.get("mode") == "percent":
                 tp = entry * (1 + float(tp_cfg["value_pct"]) / 100)
+            elif tp_cfg and tp_cfg.get("mode") == "adaptive_risk_atr":
+                _, tp = _adaptive_levels(df, i - 1, entry, cfg)
             elif name == "S4_channel_rebound":
                 target = tp_cfg.get("tp2", "channel_upper_band")
                 tp = float(df.loc[i - 1, "ChannelUpper" if target == "channel_upper_band" else "ChannelMid"])
@@ -298,7 +328,11 @@ def latest_orders(prices: pd.DataFrame, name: str, cfg: dict, general: dict) -> 
             continue
         row = df.iloc[-1]
         entry = float(row.Close)  # indicative; execution is next open in backtest
-        if name == "S4_channel_rebound":
+        if cfg.get("stop_loss", {}).get("mode") == "adaptive_atr_structure":
+            stop, tp1 = _adaptive_levels(df, len(df) - 1, entry, cfg)
+            tp2 = tp1
+            reason = f"{cfg.get('entry', {}).get('mode', name)}_adaptive_levels"
+        elif name == "S4_channel_rebound":
             stop = min(float(row.Low), float(row.ChannelLower)) - \
                 float(cfg["stop_loss"].get("atr_multiplier", 0.6)) * float(row.ATR14)
             tp1, tp2 = float(row.ChannelMid), float(row.ChannelUpper)
@@ -474,8 +508,10 @@ def run_backtest(prices: pd.DataFrame, config: dict) -> dict:
                         "buffer_pct": tranche.get("buffer_pct", 0.3),
                     },
                     "stop_loss": {
-                        "mode": "percent",
-                        "value_pct": tranche.get("stop_pct", 10.0),
+                        "mode": "adaptive_atr_structure",
+                        "lookback_days": tranche.get("stop_lookback_days", 20),
+                        "atr_multiple": tranche.get("stop_atr_multiple", 2.5),
+                        "structure_buffer_atr": tranche.get("structure_buffer_atr", 0.25),
                     },
                 }
             else:

--- a/etf-trading-engine/src/engine/operations.py
+++ b/etf-trading-engine/src/engine/operations.py
@@ -6,7 +6,6 @@ from .trading_costs import FinecoCosts, position_size
 
 
 def build_orders(signals: pd.DataFrame, capital: float, risk_pct: float = 1.5,
-                 stop_pct: float = 7.0, take_profit_pct: float = 14.0,
                  costs: FinecoCosts | None = None, max_positions: int = 3) -> pd.DataFrame:
     costs = costs or FinecoCosts()
     columns = ["Ticker", "Action", "Entry", "Exit", "Stop", "Target", "Quantity",
@@ -16,12 +15,20 @@ def build_orders(signals: pd.DataFrame, capital: float, risk_pct: float = 1.5,
     price_col = next((c for c in ("Entry", "Close", "Price") if c in signals), None)
     if not price_col:
         return pd.DataFrame(columns=columns)
+    if "Stop" not in signals or not ({"TP1", "Target"} & set(signals.columns)):
+        raise ValueError(
+            "Each operation must include strategy-calculated Stop and TP1/Target levels"
+        )
     rows = []
     allocation_pct = 100 / max(1, max_positions)
     for _, signal in signals.head(max_positions).iterrows():
         entry = float(signal[price_col])
-        stop = float(signal.get("Stop", entry * (1 - stop_pct / 100)))
-        target = float(signal.get("TP1", signal.get("Target", entry * (1 + take_profit_pct / 100))))
+        stop = float(signal["Stop"])
+        target = float(signal["TP1"] if "TP1" in signal else signal["Target"])
+        if not (stop < entry < target):
+            raise ValueError(
+                f"Invalid calculated levels for {signal['Ticker']}: require Stop < Entry < Target"
+            )
         qty = position_size(capital, risk_pct, entry, stop, costs, allocation_pct)
         rows.append({
             "Ticker": signal["Ticker"], "Action": "BUY", "Entry": entry,

--- a/etf-trading-engine/tests/test_trading_costs.py
+++ b/etf-trading-engine/tests/test_trading_costs.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from src.engine.operations import build_orders
 from src.engine.trading_costs import FinecoCosts, position_size
@@ -20,9 +21,18 @@ def test_position_size_respects_cash_and_risk():
 
 
 def test_operational_orders_have_required_levels():
-    signals = pd.DataFrame([{"Ticker": "ETF.MI", "Entry": 100, "Reason": "breakout"}])
+    signals = pd.DataFrame([{
+        "Ticker": "ETF.MI", "Entry": 100, "Stop": 94.5, "TP1": 111.25,
+        "Reason": "breakout",
+    }])
     orders = build_orders(signals, 10_000, costs=FinecoCosts(0, 0))
-    assert orders.loc[0, "Stop"] == 93
-    assert round(orders.loc[0, "Target"], 8) == 114
+    assert orders.loc[0, "Stop"] == 94.5
+    assert round(orders.loc[0, "Target"], 8) == 111.25
     assert orders.loc[0, "Quantity"] > 0
     assert "stop" in orders.loc[0, "Exit"]
+
+
+def test_operational_orders_reject_fixed_percentage_fallbacks():
+    signals = pd.DataFrame([{"Ticker": "ETF.MI", "Entry": 100}])
+    with pytest.raises(ValueError, match="strategy-calculated"):
+        build_orders(signals, 10_000, costs=FinecoCosts(0, 0))


### PR DESCRIPTION
## Modifiche
- sostituisce stop e target percentuali fissi con livelli adattivi basati su ATR e struttura di prezzo
- aggiunge la strategia S8 di falsa rottura e recupero del supporto
- blocca la creazione di ordini privi di livelli calcolati dalla strategia
- aggiorna backtest e test automatici

## Verifica
- 21 test superati in un ambiente Python pulito