### PR TITLE
Add fail-closed real-money safety gates

### DIFF
--- a/.github/workflows/unified.yml
+++ b/.github/workflows/unified.yml
@@ -71,6 +71,30 @@ jobs:
             --data etf-trading-engine/data/eod.csv \
             --outdir outputs
 
+      - name: Out-of-sample economic validation
+        env:
+          PYTHONPATH: ${{ github.workspace }}/etf-trading-engine
+        run: |
+          python etf-trading-engine/scripts/walk_forward.py \
+            --config etf-trading-config/model.yaml \
+            --data etf-trading-engine/data/eod.csv \
+            --windows etf-trading-config/wf_windows.yaml \
+            --outdir outputs/walk_forward \
+            --all-strategies
+          python etf-trading-engine/scripts/economic_gate.py \
+            --walk-forward outputs/walk_forward/wf_report.json \
+            --output outputs/economic_validation.json
+
+      - name: Build fail-closed operational proposals
+        env:
+          PYTHONPATH: ${{ github.workspace }}/etf-trading-engine
+        run: |
+          python etf-trading-engine/scripts/operational_report.py \
+            --data etf-trading-engine/data/eod.csv \
+            --config etf-trading-config/operational.yaml \
+            --validation outputs/economic_validation.json \
+            --outdir outputs
+
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/etf-trading-config/operational.yaml
+++ b/etf-trading-config/operational.yaml
@@ -1,11 +1,15 @@
 trading:
-  capital_eur: 10000
-  lines: 3
-  breakout_margin_pct: 0.3
-  sl_pct: 7
-  tp_pct: 14
-  p_win: 0.45
-  risk_per_trade_pct: 1.5
+  capital_eur: 105000
+  max_positions: 3
+  max_allocation_per_position_pct: 50
+  risk_per_trade_pct: 1.0
+  max_total_risk_pct: 3.0
+  min_average_daily_value_eur: 100000
+  max_data_age_days: 5
+  validation_max_age_days: 7
+  order_type: "LIMIT"
+  execution_mode: "PROPOSAL_ONLY"
+  manual_confirmation_required: true
   horizon: "20–60 gg"
   prefer_signals: true
   tickers_override: []

--- a/etf-trading-engine/scripts/economic_gate.py
+++ b/etf-trading-engine/scripts/economic_gate.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Convert walk-forward evidence into an explicit, auditable trading gate."""
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+
+
+def evaluate(report: dict, min_windows: int, min_sharpe: float,
+             min_profit_factor: float, max_drawdown: float) -> dict:
+    approved, details = [], {}
+    for strategy, values in report.get("aggregates", {}).items():
+        windows = [
+            row for row in report.get("windows", [])
+            if row.get("strategy") == strategy
+        ]
+        positive = sum(float(row.get("CAGR", 0) or 0) > 0 for row in windows)
+        checks = {
+            "enough_windows": len(windows) >= min_windows,
+            "majority_positive": positive > len(windows) / 2,
+            "sharpe": float(values.get("sharpe_mean", -999)) >= min_sharpe,
+            "profit_factor": float(values.get("profit_factor_mean", 0)) >= min_profit_factor,
+            "drawdown": abs(float(values.get("maxdd_mean", -999))) <= max_drawdown,
+            "has_trades": int(values.get("trades_total", 0)) > 0,
+        }
+        details[strategy] = {**values, "positive_windows": positive, "checks": checks}
+        if all(checks.values()):
+            approved.append(strategy)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "PASS" if approved else "BLOCKED",
+        "approved_strategies": approved,
+        "reason": "validated strategies available" if approved else "no strategy passed out-of-sample gates",
+        "criteria": {
+            "min_windows": min_windows, "min_sharpe": min_sharpe,
+            "min_profit_factor": min_profit_factor,
+            "max_abs_drawdown": max_drawdown,
+            "majority_positive_windows": True,
+        },
+        "strategies": details,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--walk-forward", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--min-windows", type=int, default=5)
+    parser.add_argument("--min-sharpe", type=float, default=0.30)
+    parser.add_argument("--min-profit-factor", type=float, default=1.10)
+    parser.add_argument("--max-drawdown", type=float, default=0.30)
+    args = parser.parse_args()
+    source = json.loads(Path(args.walk_forward).read_text(encoding="utf-8"))
+    result = evaluate(source, args.min_windows, args.min_sharpe,
+                      args.min_profit_factor, args.max_drawdown)
+    Path(args.output).write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"Economic gate: {result['status']} ({len(result['approved_strategies'])} approved)")
+
+
+if __name__ == "__main__":
+    main()

--- a/etf-trading-engine/scripts/operational_report.py
+++ b/etf-trading-engine/scripts/operational_report.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 ENGINE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ENGINE_ROOT))
 from src.engine.operations import build_orders
+from src.engine.safety import data_is_fresh, load_economic_validation
 from src.engine.trading_costs import FinecoCosts
 
 def safe_read_csv(path, **kwargs):
@@ -109,6 +110,8 @@ def main():
     ap.add_argument("--data", required=True, help="CSV EOD (Date,Ticker,Open,High,Low,Close,Volume...)")
     ap.add_argument("--config", required=False, help="operational.yaml (opzionale)")
     ap.add_argument("--outdir", required=True)
+    ap.add_argument("--validation", required=True,
+                    help="Fresh economic validation JSON; missing/failed means zero proposals")
     ap.add_argument("--commission", type=float, default=19.0, help="Commissione per eseguito in EUR")
     ap.add_argument("--spread-bps", type=float, default=10.0, help="Spread denaro-lettera in basis point")
     ap.add_argument("--tax-rate", type=float, default=26.0, help="Aliquota sulle plusvalenze in percentuale")
@@ -136,11 +139,27 @@ def main():
         except Exception as e:
             print(f"[WARN] config non parsabile: {e}", file=sys.stderr)
     capital = float(trading.get("capital_eur", 10_000))
-    risk_pct = float(trading.get("risk_per_trade_pct", 1.5))
+    risk_pct = float(trading.get("risk_per_trade_pct", 1.0))
     costs = FinecoCosts(args.commission, args.spread_bps, args.tax_rate / 100)
-    orders = build_orders(entries, capital, risk_pct, float(trading.get("sl_pct", 7)),
-                          float(trading.get("tp_pct", 14)), costs,
-                          int(trading.get("lines", 3)))
+    validation = load_economic_validation(
+        args.validation, int(trading.get("validation_max_age_days", 7)))
+    fresh, freshness_reason = data_is_fresh(
+        eod, int(trading.get("max_data_age_days", 5)))
+    if validation.get("status") == "PASS" and fresh:
+        orders = build_orders(
+            entries, capital, risk_pct, costs,
+            int(trading.get("max_positions", 3)),
+            float(trading.get("max_allocation_per_position_pct", 50)),
+            float(trading.get("max_total_risk_pct", 3)),
+            set(validation.get("approved_strategies", [])),
+            proposal_only=True,
+        )
+        operational_status = "PROPOSAL_ONLY"
+        blocked_reason = None
+    else:
+        orders = build_orders(pd.DataFrame(), capital)
+        operational_status = "BLOCKED"
+        blocked_reason = validation.get("reason") if validation.get("status") != "PASS" else freshness_reason
 
     # drawdown medio (fallback)
     dd_avg = simple_drawdown(eod)
@@ -160,6 +179,9 @@ def main():
     ts_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     md = []
     md.append(f"# Operational Report — {ts_utc}\n")
+    md.append(f"- Stato operativo: **{operational_status}**")
+    if blocked_reason:
+        md.append(f"- Motivo del blocco: **{blocked_reason}**")
     md.append(f"- Universe: **{universe_n}** ticker")
     if last_dt is not None:
         md.append(f"- Ultima data EOD: **{last_dt.date()}**")
@@ -190,6 +212,9 @@ def main():
         "drawdown_avg": dd_avg,
         "signals_rows": int(entries.shape[0]) if not entries.empty else 0,
         "payoff_mean_estimate": expected_cycle
+        ,"operational_status": operational_status
+        ,"blocked_reason": blocked_reason
+        ,"approved_strategies": validation.get("approved_strategies", [])
     }
     (outdir / "operational_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
     orders.to_csv(outdir / "operational_orders.csv", index=False)

--- a/etf-trading-engine/src/engine/operations.py
+++ b/etf-trading-engine/src/engine/operations.py
@@ -5,11 +5,17 @@ import pandas as pd
 from .trading_costs import FinecoCosts, position_size
 
 
-def build_orders(signals: pd.DataFrame, capital: float, risk_pct: float = 1.5,
-                 costs: FinecoCosts | None = None, max_positions: int = 3) -> pd.DataFrame:
+def build_orders(signals: pd.DataFrame, capital: float, risk_pct: float = 1.0,
+                 costs: FinecoCosts | None = None, max_positions: int = 3,
+                 max_allocation_pct: float = 50.0,
+                 max_total_risk_pct: float = 3.0,
+                 approved_strategies: set[str] | None = None,
+                 proposal_only: bool = True) -> pd.DataFrame:
     costs = costs or FinecoCosts()
-    columns = ["Ticker", "Action", "Entry", "Exit", "Stop", "Target", "Quantity",
-               "PositionValue", "RiskEUR", "CommissionRT", "TaxRate", "Reason"]
+    columns = ["Status", "RequiresManualConfirmation", "Ticker", "Action",
+               "OrderType", "LimitPrice", "Entry", "Exit", "Stop", "Target",
+               "Quantity", "PositionValue", "RiskEUR", "CommissionRT",
+               "TaxRate", "Strategy", "Reason"]
     if signals.empty or "Ticker" not in signals:
         return pd.DataFrame(columns=columns)
     price_col = next((c for c in ("Entry", "Close", "Price") if c in signals), None)
@@ -20,8 +26,12 @@ def build_orders(signals: pd.DataFrame, capital: float, risk_pct: float = 1.5,
             "Each operation must include strategy-calculated Stop and TP1/Target levels"
         )
     rows = []
-    allocation_pct = 100 / max(1, max_positions)
+    total_risk = 0.0
+    risk_cap = capital * max_total_risk_pct / 100
     for _, signal in signals.head(max_positions).iterrows():
+        strategy = str(signal.get("Run", signal.get("Strategy", "")))
+        if approved_strategies is not None and strategy not in approved_strategies:
+            continue
         entry = float(signal[price_col])
         stop = float(signal["Stop"])
         target = float(signal["TP1"] if "TP1" in signal else signal["Target"])
@@ -29,13 +39,21 @@ def build_orders(signals: pd.DataFrame, capital: float, risk_pct: float = 1.5,
             raise ValueError(
                 f"Invalid calculated levels for {signal['Ticker']}: require Stop < Entry < Target"
             )
-        qty = position_size(capital, risk_pct, entry, stop, costs, allocation_pct)
+        qty = position_size(capital, risk_pct, entry, stop, costs, max_allocation_pct)
+        risk_eur = qty * (entry - stop) + 2 * costs.commission_eur
+        if qty <= 0 or total_risk + risk_eur > risk_cap:
+            continue
+        total_risk += risk_eur
         rows.append({
-            "Ticker": signal["Ticker"], "Action": "BUY", "Entry": entry,
+            "Status": "PROPOSAL_ONLY" if proposal_only else "APPROVED",
+            "RequiresManualConfirmation": True,
+            "Ticker": signal["Ticker"], "Action": "BUY", "OrderType": "LIMIT",
+            "LimitPrice": entry, "Entry": entry,
             "Exit": f"Target {target:.2f} o stop {stop:.2f}", "Stop": stop,
             "Target": target, "Quantity": qty, "PositionValue": qty * entry,
-            "RiskEUR": qty * (entry - stop) + 2 * costs.commission_eur,
+            "RiskEUR": risk_eur,
             "CommissionRT": 2 * costs.commission_eur, "TaxRate": costs.tax_rate,
+            "Strategy": strategy,
             "Reason": signal.get("Reason", "Segnale quantitativo"),
         })
     return pd.DataFrame(rows, columns=columns)

--- a/etf-trading-engine/src/engine/safety.py
+++ b/etf-trading-engine/src/engine/safety.py
@@ -1,0 +1,45 @@
+"""Fail-closed gates for real-money trading proposals."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import json
+
+import pandas as pd
+
+
+def load_economic_validation(path: str | Path, max_age_days: int = 7,
+                             now: datetime | None = None) -> dict:
+    """Return a validation report or a BLOCKED result for any uncertainty."""
+    now = now or datetime.now(timezone.utc)
+    path = Path(path)
+    if not path.exists():
+        return {"status": "BLOCKED", "reason": "economic validation report missing"}
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+        generated = pd.Timestamp(report["generated_at"])
+        if generated.tzinfo is None:
+            generated = generated.tz_localize("UTC")
+        age = now - generated.to_pydatetime()
+        if age.total_seconds() < 0 or age.days > max_age_days:
+            return {"status": "BLOCKED", "reason": "economic validation expired"}
+        if report.get("status") != "PASS" or not report.get("approved_strategies"):
+            return {"status": "BLOCKED", "reason": report.get("reason", "no approved strategy")}
+        return report
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        return {"status": "BLOCKED", "reason": f"invalid economic validation: {exc}"}
+
+
+def data_is_fresh(eod: pd.DataFrame, max_age_days: int = 5,
+                  now: datetime | None = None) -> tuple[bool, str]:
+    now = now or datetime.now(timezone.utc)
+    if eod.empty or "Date" not in eod:
+        return False, "market data missing"
+    dates = pd.to_datetime(eod["Date"], errors="coerce", utc=True).dropna()
+    if dates.empty:
+        return False, "market dates invalid"
+    age = now - dates.max().to_pydatetime()
+    if age.total_seconds() < 0 or age.days > max_age_days:
+        return False, f"market data stale ({age.days} days)"
+    return True, "ok"

--- a/etf-trading-engine/tests/test_safety.py
+++ b/etf-trading-engine/tests/test_safety.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timezone
+import json
+
+import pandas as pd
+
+from src.engine.operations import build_orders
+from src.engine.safety import data_is_fresh, load_economic_validation
+from scripts.economic_gate import evaluate
+
+
+def signal(strategy="S3_breakout_checklist"):
+    return pd.DataFrame([{
+        "Ticker": "ETF.MI", "Entry": 100, "Stop": 95, "TP1": 110,
+        "Run": strategy, "Reason": "test",
+    }])
+
+
+def test_missing_or_failed_validation_blocks(tmp_path):
+    assert load_economic_validation(tmp_path / "missing.json")["status"] == "BLOCKED"
+    path = tmp_path / "gate.json"
+    path.write_text(json.dumps({
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "BLOCKED", "approved_strategies": [],
+    }))
+    assert load_economic_validation(path)["status"] == "BLOCKED"
+
+
+def test_orders_are_proposals_and_require_manual_confirmation():
+    orders = build_orders(signal(), 105_000, approved_strategies={"S3_breakout_checklist"})
+    assert orders.loc[0, "Status"] == "PROPOSAL_ONLY"
+    assert bool(orders.loc[0, "RequiresManualConfirmation"])
+    assert orders.loc[0, "OrderType"] == "LIMIT"
+    assert orders.loc[0, "PositionValue"] <= 52_500
+
+
+def test_unapproved_strategy_produces_zero_orders():
+    orders = build_orders(signal("S5_trend_pullback"), 105_000,
+                          approved_strategies={"S3_breakout_checklist"})
+    assert orders.empty
+
+
+def test_aggregate_risk_is_capped():
+    signals = pd.concat([signal().assign(Ticker=f"ETF{i}.MI") for i in range(5)])
+    orders = build_orders(signals, 105_000, risk_pct=2,
+                          max_positions=5, max_total_risk_pct=3,
+                          approved_strategies={"S3_breakout_checklist"})
+    assert orders["RiskEUR"].sum() <= 3_150
+
+
+def test_stale_market_data_blocks():
+    old = pd.DataFrame({"Date": ["2020-01-01"]})
+    ok, reason = data_is_fresh(old, now=datetime(2026, 7, 28, tzinfo=timezone.utc))
+    assert not ok
+    assert "stale" in reason
+
+
+def test_economic_gate_requires_all_thresholds():
+    report = {
+        "windows": [
+            {"strategy": "S3", "CAGR": .1} for _ in range(4)
+        ] + [{"strategy": "S3", "CAGR": -.1}],
+        "aggregates": {"S3": {
+            "windows_count": 5, "sharpe_mean": .4,
+            "profit_factor_mean": 1.2, "maxdd_mean": -.2,
+            "trades_total": 10,
+        }},
+    }
+    assert evaluate(report, 5, .3, 1.1, .3)["status"] == "PASS"
+    report["aggregates"]["S3"]["profit_factor_mean"] = .9
+    assert evaluate(report, 5, .3, 1.1, .3)["status"] == "BLOCKED"


### PR DESCRIPTION
## Cosa cambia
- aggiorna il capitale operativo a €105.000
- rimuove i vecchi fallback fissi stop -7% / target +14%
- aggiunge validazione economica walk-forward con scadenza
- blocca qualsiasi proposta con dati vecchi o strategia non approvata
- limita il rischio all'1% per operazione, 3% complessivo e 50% per ETF
- produce esclusivamente ordini LIMIT in stato `PROPOSAL_ONLY`
- richiede conferma manuale prima dell'inserimento su Fineco

## Motivo
Il flusso operativo precedente poteva generare un piano senza una prova economica recente e conteneva ancora parametri fissi ormai superati.

## Verifiche
- 33 test automatici superati
- YAML del workflow e della configurazione validi
- compilazione Python completata
- prova end-to-end: validazione assente => `BLOCKED` e zero ordini
- `git diff --check` superato